### PR TITLE
feat: 회원탈퇴 API 작성 및 테스트코드 추가

### DIFF
--- a/src/main/kotlin/wscrg/exposeuback/api/user/controller/UserApiController.kt
+++ b/src/main/kotlin/wscrg/exposeuback/api/user/controller/UserApiController.kt
@@ -52,4 +52,9 @@ class UserApiController(
         val userDto = securityContextImpl.authentication.principal as UserDto
         return ResponseEntity.ok(userDto)
     }
+
+    @DeleteMapping("/{id}")
+    fun quit(@PathVariable id: Long) {
+        userService.delete(id)
+    }
 }

--- a/src/main/kotlin/wscrg/exposeuback/domain/entity/User.kt
+++ b/src/main/kotlin/wscrg/exposeuback/domain/entity/User.kt
@@ -35,7 +35,7 @@ class User private constructor(
     var password = password
         protected set
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "UPLOAD_FILE_ID", nullable = false)
     var image = image
         protected set

--- a/src/main/kotlin/wscrg/exposeuback/service/UserService.kt
+++ b/src/main/kotlin/wscrg/exposeuback/service/UserService.kt
@@ -25,5 +25,4 @@ class UserService(
     }
 
     fun delete(id: Long) = userRepository.deleteById(id)
-
 }

--- a/src/test/kotlin/wscrg/exposeuback/api/user/controller/UserApiControllerTest.kt
+++ b/src/test/kotlin/wscrg/exposeuback/api/user/controller/UserApiControllerTest.kt
@@ -1,6 +1,7 @@
 package wscrg.exposeuback.api.user.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -9,56 +10,33 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.mock.web.MockMultipartFile
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.transaction.annotation.Transactional
 import wscrg.exposeuback.domain.dto.user.UserForm
+import java.util.UUID
 
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 internal class UserApiControllerTest private constructor(
     @Autowired
     val mockMvc: MockMvc,
-    @Autowired
-    val objectMapper: ObjectMapper
 ) {
     companion object {
         val log = LoggerFactory.getLogger(MockMvcResultMatchers::class.java)
     }
 
+    val objectMapper = ObjectMapper().registerKotlinModule()
+
     @Test
     fun user_and_image_동시_업로드_테스트() {
         //given
-        val imageFile = MockMultipartFile(
-            "file-data",
-            "image.jpeg",
-            MediaType.IMAGE_JPEG_VALUE,
-            "<<image jpeg>>".toByteArray()
-        )
-
-        val content =
-            objectMapper.writeValueAsString(
-                UserForm(
-                    email = "abcdefu@google.com",
-                    username = "jiji",
-                    password = "1234"
-                )
-            )
-
-        val json = MockMultipartFile(
-            "user-data",
-            "jsonData",
-            MediaType.APPLICATION_JSON_VALUE,
-            content.toByteArray()
-        )
+        val requestBuilder = createMockUser(hasImage = true)
 
         //when
-        val requestBuilder = multipart("/api/users")
-            .file(imageFile)
-            .file(json)
-            .contentType(MediaType.MULTIPART_MIXED_VALUE)
-            .characterEncoding("UTF-8")
-
         val perform = mockMvc.perform(requestBuilder)
 
         //then
@@ -72,10 +50,70 @@ internal class UserApiControllerTest private constructor(
     fun image_미업로드시_400_응답() {
         //given
         //file-data 없음
+        val requestBuilder = createMockUser(hasImage = false)
+
+        //when
+        val perform = mockMvc.perform(requestBuilder)
+
+        //then
+        perform.andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun 회원조회() {
+        //given
+        val requestBuilder = createMockUser(hasImage = true)
+
+        val perform = mockMvc.perform(requestBuilder)
+        val mvcResult = perform.andReturn()
+        val userResponseDto = objectMapper.readValue(mvcResult.response.contentAsString, UserResponseDto::class.java)
+
+        //when
+        val resultActions = mockMvc.perform(
+            get("/api/users/${userResponseDto.id}")
+        )
+
+        //then
+        resultActions.andExpect(status().isOk)
+    }
+
+    @Test
+    fun 회원탈퇴() {
+        //given
+        val requestBuilder = createMockUser(hasImage = true)
+
+        val perform = mockMvc.perform(requestBuilder)
+        val mvcResult = perform.andReturn()
+        val userResponseDto = objectMapper.readValue(mvcResult.response.contentAsString, UserResponseDto::class.java)
+
+        val jsonData = HashMap<String, Long>()
+        jsonData["id"] = userResponseDto.id
+
+        //when
+        val resultActions = mockMvc.perform(
+            delete("/api/users/${userResponseDto.id}")
+        )
+
+        //then
+        resultActions.andExpect(status().isOk)
+    }
+
+    fun createMockUser(hasImage: Boolean): MockHttpServletRequestBuilder {
+        val imageFile = if (hasImage)
+            MockMultipartFile(
+                "file-data",
+                "image.jpeg",
+                MediaType.IMAGE_JPEG_VALUE,
+                "<<image jpeg>>".toByteArray()
+            ) else null
+
+        var random = UUID.randomUUID().toString()
+        random = random.substring(random.lastIndexOf("-") + 1)
+
         val content =
             objectMapper.writeValueAsString(
                 UserForm(
-                    email = "abcdefu@google.com",
+                    email = "${random}@google.com",
                     username = "jiji",
                     password = "1234"
                 )
@@ -88,15 +126,21 @@ internal class UserApiControllerTest private constructor(
             content.toByteArray()
         )
 
-        //when
-        val requestBuilder = multipart("/api/users")
-            .file(json)
-            .contentType(MediaType.MULTIPART_MIXED_VALUE)
-            .characterEncoding("UTF-8")
-
-        val perform = mockMvc.perform(requestBuilder)
-
-        //then
-        val result = perform.andExpect(status().isBadRequest)
+        return when (hasImage) {
+            true -> multipart("/api/users")
+                .file(imageFile!!)
+                .file(json)
+                .contentType(MediaType.MULTIPART_MIXED_VALUE)
+                .characterEncoding("UTF-8")
+            false -> multipart("/api/users")
+                .file(json)
+                .contentType(MediaType.MULTIPART_MIXED_VALUE)
+                .characterEncoding("UTF-8")
+        }
     }
+
+    data class UserResponseDto(
+        var id: Long,
+        var email: String
+    )
 }


### PR DESCRIPTION
## 개요
User 엔티티 수정 및 회원탈퇴 API 개발에 대한 PR입니다.

## 변경사항
User-UploadFile 간 cacade와 orphanRemoval 적용, 회원탈퇴 API 작성 및 테스트 코드를 작성했습니다.

## 변경로직
```
//User.kt
@OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
    @JoinColumn(name = "UPLOAD_FILE_ID", nullable = false)
    var image = image
        protected set
```

```
//UserApiController.kt
    @DeleteMapping("/{id}")
    fun quit(@PathVariable id: Long) {
        userService.delete(id)
    }
```