### PR TITLE
fix: User 조회 시 Image 관련 버그 수정, 응답 엔티티 개발 및 적용

### DIFF
--- a/src/main/kotlin/wscrg/exposeuback/api/user/controller/UserApiController.kt
+++ b/src/main/kotlin/wscrg/exposeuback/api/user/controller/UserApiController.kt
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
 import wscrg.exposeuback.domain.dto.authentication.UserDto
 import wscrg.exposeuback.domain.dto.user.UserForm
+import wscrg.exposeuback.domain.dto.user.UserResponseDto
 import wscrg.exposeuback.domain.dto.user.UserSignUpRequestDto
 import wscrg.exposeuback.domain.dto.user.UserSignUpResponseDto
 import wscrg.exposeuback.domain.entity.UploadFile
@@ -23,7 +24,13 @@ class UserApiController(
     val fileUtil: FileUtil
 ) {
     @GetMapping("/{id}")
-    fun getUser(@PathVariable id: Long) = userService.findById(id)
+    fun getUser(@PathVariable id: Long): ResponseEntity<UserResponseDto> {
+        val foundUser = userService.findById(id)
+
+        return with(foundUser) {
+            ResponseEntity.ok(UserResponseDto(id = id, email = email, username = username, image = image))
+        }
+    }
 
     @PostMapping
     fun signUp(

--- a/src/main/kotlin/wscrg/exposeuback/api/user/controller/advice/UserApiControllerAdvice.kt
+++ b/src/main/kotlin/wscrg/exposeuback/api/user/controller/advice/UserApiControllerAdvice.kt
@@ -1,11 +1,9 @@
 package wscrg.exposeuback.api.user.controller.advice
 
-import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.*
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
-import wscrg.exposeuback.api.user.controller.UserApiController
 import wscrg.exposeuback.domain.dto.error.ErrorResult
 
 @RestControllerAdvice("wscrg.exposeuback.api")

--- a/src/main/kotlin/wscrg/exposeuback/domain/dto/user/userGeneralDto.kt
+++ b/src/main/kotlin/wscrg/exposeuback/domain/dto/user/userGeneralDto.kt
@@ -1,0 +1,10 @@
+package wscrg.exposeuback.domain.dto.user
+
+import wscrg.exposeuback.domain.entity.UploadFile
+
+data class UserResponseDto(
+    var id: Long,
+    var email: String,
+    var username: String,
+    var image: UploadFile?
+)

--- a/src/main/kotlin/wscrg/exposeuback/repository/UserRepository.kt
+++ b/src/main/kotlin/wscrg/exposeuback/repository/UserRepository.kt
@@ -1,9 +1,14 @@
 package wscrg.exposeuback.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import wscrg.exposeuback.domain.entity.User
 
 interface UserRepository : JpaRepository<User, Long> {
 
     fun findByEmail(name: String): User?
+
+    @Query("select u from User u join fetch u.image where u.id = :id")
+    fun findByIdOrNull(@Param("id") id: Long): User?
 }

--- a/src/main/kotlin/wscrg/exposeuback/service/UserService.kt
+++ b/src/main/kotlin/wscrg/exposeuback/service/UserService.kt
@@ -1,7 +1,5 @@
 package wscrg.exposeuback.service
 
-import org.springframework.data.repository.findByIdOrNull
-import org.springframework.security.core.userdetails.UsernameNotFoundException
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -16,7 +14,7 @@ class UserService(
 ) {
     fun findById(id: Long): User =
         userRepository.findByIdOrNull(id)
-            ?: throw UsernameNotFoundException(String.format("No user was founded. id: %s", id))
+            ?: throw IllegalArgumentException(String.format("No user was founded. id: %s", id))
 
     @Transactional
     fun save(userRequestDto: UserSignUpRequestDto): User {


### PR DESCRIPTION
## 개요
기존 로직으로 User 조회 시 FetchType이 Lazy로 되어 있던 Image 컬럼에서 hibernateLazyInitializer 관련 에러가 발생헀다. 이를 fetch join을 통해 해결했다.
그리고 응답 엔티티를 개발하여 엔티티를 노출시키지 않도록 했고 관련 예외 처리를 하였다.

## 변경로직

```
//UserApiController.kt
    // ...

    @GetMapping("/{id}")
    fun getUser(@PathVariable id: Long): ResponseEntity<UserResponseDto> {
        val foundUser = userService.findById(id)

        return with(foundUser) {
            ResponseEntity.ok(UserResponseDto(id = id, email = email, username = username, image = image))
        }
    }

    // ...
```

```
//UserService.kt
    // ...

    fun findById(id: Long): User =
        userRepository.findByIdOrNull(id)
            ?: throw IllegalArgumentException(String.format("No user was founded. id: %s", id))

   // ...
```

```
//UserRepository
    // ...

    @Query("select u from User u join fetch u.image where u.id = :id")
    fun findByIdOrNull(@Param("id") id: Long): User?
```